### PR TITLE
chore: add project-level Claude Code permission settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(mkdir:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with project-level Bash permissions for `git`, `gh`, `pip`, `pip3`, `python`, `python3`, and `mkdir` — captured from commands approved during this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)